### PR TITLE
feat: add AgentState Pydantic schema

### DIFF
--- a/src/models/__init__.py
+++ b/src/models/__init__.py
@@ -1,0 +1,4 @@
+from .agent_state import AgentState
+
+__all__ = ["AgentState"]
+

--- a/src/models/agent_state.py
+++ b/src/models/agent_state.py
@@ -1,0 +1,19 @@
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+
+class AgentState(BaseModel):
+    """
+    Estado base de un agente (por ejemplo, al orquestar un flujo con LangGraph).
+
+    Nota: los issues posteriores pueden extender este modelo con tipos más específicos
+    (por ejemplo, `ReviewComment`).
+    """
+
+    repo_full_name: str = Field(..., min_length=1)
+    pr_number: int = Field(..., ge=1)
+    status: str = Field(..., min_length=1)
+    messages: list[str]
+    review_comments: list[dict[str, Any]] = Field(default_factory=list)
+


### PR DESCRIPTION
## Summary
Agrega el schema base `AgentState` de Pydantic para que el estado del agente sea importable y validable desde otros módulos.

## Test plan
- Ejecutado: `./.venv/bin/python -c "from src.models import AgentState; AgentState(repo_full_name="org/repo", pr_number=1, status="pending", messages=["hi"])"`

## Risks
- El modelo es intencionalmente mínimo; issues posteriores podrán extenderlo con tipos más específicos (por ejemplo, `ReviewComment`).

Closes #10