### PR TITLE
feat: implementar Circuit Breaker para llamadas LLM (#42)

### DIFF
--- a/.agents/architect.md
+++ b/.agents/architect.md
@@ -8,6 +8,44 @@ Analizo decisiones de arquitectura y diseño del proyecto.
 - Verificar uso correcto de patrones (Adapter, Factory, Observer)
 - Identificar acoplamiento excesivo
 - Proponer refactors cuando sea necesario
+- Asegurar patrones de resilience (Circuit Breaker, Retry, Fallback)
+
+## Patrones de Arquitectura
+
+### Patrones de Diseño
+| Patrón | Uso |
+|--------|-----|
+| Adapter | Unificar interfaces de LLM (Groq, Gemini, Ollama) |
+| Factory | Crear agentes según tipo |
+| Observer | Notificar eventos a listeners |
+| Strategy | Elegir algoritmo de review según contexto |
+| Decorator | Agregar logging, caching sin modificar código |
+
+### Patrones de Resilience (ver solid.md para detalle)
+| Patrón | Implementación obligatoria |
+|--------|---------------------------|
+| Circuit Breaker | Para GitHub API y LLM |
+| Retry + Backoff | Para operaciones de red |
+| Timeout | Para toda llamada externa |
+| Fallback | Cuando servicios fallan |
+
+## Checklist de Arquitectura
+
+### Hexagonal
+- [ ] Puertos definidos (interfaces)
+- [ ] Adaptadores separados de dominio
+- [ ] Sin dependencias circulares
+
+### Patrones
+- [ ] SOLID respetado
+- [ ] DRY aplicado
+- [ ] Inyección de dependencias
+
+### Resilience
+- [ ] Circuit Breaker
+- [ ] Retry con backoff
+- [ ] Timeouts
+- [ ] Fallbacks
 
 ## Cuando intervenir
 Este agente interviene cuando:

--- a/.agents/solid.md
+++ b/.agents/solid.md
@@ -10,6 +10,32 @@ Verifico que el código cumpla con principios SOLID.
 - **I**nterface Segregation: ¿Interfaces pequeñas y específicas?
 - **D**ependency Inversion: ¿Depende de abstracciones, no concreciones?
 
+### Patrones de Resilience (obligatorios para sistemas con IA)
+
+| Patrón | Cuándo aplicar | Qué hace |
+|--------|----------------|----------|
+| **Circuit Breaker** | Llamadas a servicios externos (GitHub, LLM) | Corta el circuito después de N fallos |
+| **Retry + Backoff** | Errores transitorios (timeout, 503) | Reintenta con espera exponencial |
+| **Fallback** | Cuando el servicio principal falla | Ejecuta alternativa (cache, default) |
+| **Timeout** | Toda llamada externa | Nunca esperar más de X segundos |
+| **Bulkhead** | Múltiples servicios | Aislar failures entre componentes |
+| **Rate Limiter** | APIs externas (GitHub tiene límites) | Controlar frecuencia de requests |
+
+## Verificación de Resilience
+
+### ¿Se implementó?
+- [ ] Circuit Breaker para llamadas LLM
+- [ ] Retry con exponential backoff
+- [ ] Timeout en todas las llamadas HTTP
+- [ ] Fallback cuando LLM no responde
+- [ ] Rate limiting para GitHub API
+
+### Anti-patterns a evitar
+- ❌ Sin timeout → infinite wait
+- ❌ Sin retry → primer error pierde todo
+- ❌ Sin circuit breaker → cascade failure
+- ❌ Sin fallback → sistema totalmente down
+
 ## Cuando intervenir
 Este agente interviene cuando:
 - Se crean nuevas clases

--- a/src/infrastructure/resilience/__init__.py
+++ b/src/infrastructure/resilience/__init__.py
@@ -1,0 +1,21 @@
+"""
+Resilience Patterns Module
+
+Contiene patrones de resilience para sistemas distribuidos:
+- Circuit Breaker: Previene cascade failures
+"""
+from src.infrastructure.resilience.circuit_breaker import (
+    CircuitBreaker,
+    CircuitBreakerConfig,
+    CircuitBreakerStats,
+    CircuitBreakerOpen,
+    CircuitState
+)
+
+__all__ = [
+    "CircuitBreaker",
+    "CircuitBreakerConfig",
+    "CircuitBreakerStats",
+    "CircuitBreakerOpen",
+    "CircuitState"
+]

--- a/src/infrastructure/resilience/circuit_breaker.py
+++ b/src/infrastructure/resilience/circuit_breaker.py
@@ -1,0 +1,259 @@
+"""
+Circuit Breaker Pattern
+
+¿Qué es?
+--------
+Imaginate un automático de luz en tu casa:
+- Normal: la luz prende y apaga (CLOSED)
+- Si hay un cortocircuito: el automático "salta" y corta (OPEN)
+- Después de un rato, probás de nuevo (HALF-OPEN)
+- Si funciona, vuelve a lo normal (CLOSED)
+
+Estados:
+--------
+CLOSED → Todo funciona, requests pasan normalmente
+   ↓ (N fallos)
+OPEN → Circuit cortado, requests rechazados inmediatamente
+   ↓ (después de timeout)
+HALF-OPEN → Se permite 1 request de prueba
+   ↓ (éxito/error)
+CLOSED / OPEN
+"""
+from enum import Enum
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+import asyncio
+import time
+
+
+class CircuitState(Enum):
+    CLOSED = "closed"    # Normal - acepta requests
+    OPEN = "open"        # Cortado - rechaza requests
+    HALF_OPEN = "half_open"  # Probando - 1 request de prueba
+
+
+@dataclass
+class CircuitBreakerConfig:
+    failure_threshold: int = 5      # Cuántos fallos abren el circuit
+    success_threshold: int = 2       # Cuántos éxitos lo cierran (half-open → closed)
+    timeout: float = 60.0           # Segundos antes de probar de nuevo
+    half_open_max_calls: int = 1     # Requests permitidos en half-open
+
+
+@dataclass
+class CircuitBreakerStats:
+    total_calls: int = 0
+    successful_calls: int = 0
+    failed_calls: int = 0
+    rejected_calls: int = 0
+    state_changes: int = 0
+    last_state_change: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
+
+
+class CircuitBreakerOpen(Exception):
+    """Excepción cuando el circuit está abierto"""
+    pass
+
+
+class CircuitBreaker:
+    """
+    Circuit Breaker - Previene cascade failures
+    
+    Ejemplo de uso:
+    -----------
+    cb = CircuitBreaker(failure_threshold=5, timeout=60)
+    
+    try:
+        resultado = cb.call(lambda: mi_funcion_que_puede_fallar())
+    except CircuitBreakerOpen:
+        print("Circuit abierto! No se puede llamar ahora")
+    
+    También puedes usarlo como decorador:
+    -----------
+    @CircuitBreaker.decorator(failure_threshold=3)
+    async def mi_llamada():
+        return await api.externa()
+    """
+    
+    def __init__(self, name: str = "default", config: CircuitBreakerConfig = None):
+        self.name = name
+        self.config = config or CircuitBreakerConfig()
+        self.state = CircuitState.CLOSED
+        self.failure_count = 0
+        self.success_count = 0
+        self.last_failure_time: float = 0
+        self.half_open_calls = 0
+        self.stats = CircuitBreakerStats()
+        self._lock = asyncio.Lock()
+    
+    @property
+    def is_closed(self) -> bool:
+        return self.state == CircuitState.CLOSED
+    
+    @property
+    def is_open(self) -> bool:
+        return self.state == CircuitState.OPEN
+    
+    @property
+    def is_half_open(self) -> bool:
+        return self.state == CircuitState.HALF_OPEN
+    
+    def _should_allow_request(self) -> bool:
+        """Decide si se permite el request según el estado"""
+        if self.state == CircuitState.CLOSED:
+            return True
+        
+        if self.state == CircuitState.OPEN:
+            # Check si pasó el timeout
+            time_since_failure = time.time() - self.last_failure_time
+            if time_since_failure >= self.config.timeout:
+                self._transition_to(CircuitState.HALF_OPEN)
+                return True
+            return False
+        
+        # HALF_OPEN: solo 1 request a la vez
+        if self.half_open_calls < self.config.half_open_max_calls:
+            self.half_open_calls += 1
+            return True
+        return False
+    
+    def _transition_to(self, new_state: CircuitState):
+        """Transiciona a un nuevo estado"""
+        if self.state != new_state:
+            self.state = new_state
+            self.stats.state_changes += 1
+            self.stats.last_state_change = datetime.now(timezone.utc)
+            
+            # Reset counters según el estado
+            if new_state == CircuitState.CLOSED:
+                self.failure_count = 0
+                self.success_count = 0
+            elif new_state == CircuitState.HALF_OPEN:
+                self.half_open_calls = 0
+                self.success_count = 0
+    
+    def _on_success(self):
+        """Maneja un éxito"""
+        self.stats.successful_calls += 1
+        
+        if self.state == CircuitState.HALF_OPEN:
+            self.success_count += 1
+            if self.success_count >= self.config.success_threshold:
+                self._transition_to(CircuitState.CLOSED)
+        elif self.state == CircuitState.CLOSED:
+            # En closed, reseteamos failure count con cada éxito
+            self.failure_count = 0
+    
+    def _on_failure(self):
+        """Maneja un fallo"""
+        self.stats.failed_calls += 1
+        self.failure_count += 1
+        self.last_failure_time = time.time()
+        
+        if self.state == CircuitState.HALF_OPEN:
+            # En half-open, cualquier fallo vuelve a abrir
+            self._transition_to(CircuitState.OPEN)
+        elif self.state == CircuitState.CLOSED:
+            if self.failure_count >= self.config.failure_threshold:
+                self._transition_to(CircuitState.OPEN)
+    
+    async def call(self, func, *args, **kwargs):
+        """
+        Ejecuta una función con Circuit Breaker
+        
+        Args:
+            func: Función async a ejecutar
+            *args, **kwargs: Argumentos para la función
+        
+        Returns:
+            El resultado de la función
+        
+        Raises:
+            CircuitBreakerOpen: Si el circuit está abierto
+        """
+        async with self._lock:
+            self.stats.total_calls += 1
+            
+            if not self._should_allow_request():
+                self.stats.rejected_calls += 1
+                raise CircuitBreakerOpen(
+                    f"Circuit '{self.name}' is OPEN. "
+                    f"Wait {self.config.timeout}s before retry."
+                )
+        
+        try:
+            if asyncio.iscoroutinefunction(func):
+                result = await func(*args, **kwargs)
+            else:
+                result = func(*args, **kwargs)
+            
+            async with self._lock:
+                self._on_success()
+            
+            return result
+            
+        except Exception as e:
+            async with self._lock:
+                self._on_failure()
+            raise
+    
+    def call_sync(self, func, *args, **kwargs):
+        """Versión síncrona para funciones que no son async"""
+        self.stats.total_calls += 1
+        
+        if not self._should_allow_request():
+            self.stats.rejected_calls += 1
+            raise CircuitBreakerOpen(
+                f"Circuit '{self.name}' is OPEN"
+            )
+        
+        try:
+            result = func(*args, **kwargs)
+            self._on_success()
+            return result
+        except Exception as e:
+            self._on_failure()
+            raise
+    
+    @staticmethod
+    def decorator(failure_threshold: int = 5, timeout: float = 60.0, name: str = None):
+        """Decorador para envolver funciones con Circuit Breaker"""
+        def decorator_func(func):
+            cb_name = name or func.__name__
+            cb = CircuitBreaker(name=cb_name, config=CircuitBreakerConfig(
+                failure_threshold=failure_threshold,
+                timeout=timeout
+            ))
+            
+            async def wrapper(*args, **kwargs):
+                return await cb.call(func, *args, **kwargs)
+            
+            wrapper.circuit_breaker = cb
+            wrapper.__name__ = func.__name__
+            return wrapper
+        return decorator_func
+    
+    def get_status(self) -> dict:
+        """Retorna el estado actual del circuit breaker"""
+        return {
+            "name": self.name,
+            "state": self.state.value,
+            "failure_count": self.failure_count,
+            "success_count": self.success_count,
+            "stats": {
+                "total_calls": self.stats.total_calls,
+                "successful_calls": self.stats.successful_calls,
+                "failed_calls": self.stats.failed_calls,
+                "rejected_calls": self.stats.rejected_calls,
+                "state_changes": self.stats.state_changes,
+                "last_state_change": self.stats.last_state_change.isoformat()
+            }
+        }
+    
+    def reset(self):
+        """Resetea el circuit breaker a estado inicial"""
+        self.state = CircuitState.CLOSED
+        self.failure_count = 0
+        self.success_count = 0
+        self.half_open_calls = 0
+        self.stats = CircuitBreakerStats()

--- a/src/llm/adapters/circuit_breaker_adapter.py
+++ b/src/llm/adapters/circuit_breaker_adapter.py
@@ -1,0 +1,77 @@
+"""
+Circuit Breaker Wrapper para LLM Adapters
+
+Envuelve un LLMPort con Circuit Breaker para prevenir cascade failures.
+"""
+from typing import Optional
+from src.llm.ports.llm_port import LLMPort, LLMResponse, LLMConfig
+from src.infrastructure.resilience.circuit_breaker import (
+    CircuitBreaker,
+    CircuitBreakerConfig,
+    CircuitBreakerOpen,
+    CircuitState
+)
+
+
+class LLMCircuitBreakerAdapter(LLMPort):
+    """
+    Adapter que envuelve otro LLMPort con Circuit Breaker.
+    
+    Uso:
+    ----
+    groq = GroqAdapter()
+    cb_groq = LLMCircuitBreakerAdapter(groq, name="groq")
+    
+    # Ahora groq tiene protección de circuit breaker
+    response = await cb_groq.complete(prompt)
+    """
+    
+    def __init__(
+        self, 
+        adapter: LLMPort,
+        name: str = None,
+        config: CircuitBreakerConfig = None
+    ):
+        self._adapter = adapter
+        self._name = name or adapter.get_provider_name()
+        self._circuit_breaker = CircuitBreaker(
+            name=self._name,
+            config=config or CircuitBreakerConfig(
+                failure_threshold=5,      # 5 fallos = abre
+                success_threshold=2,      # 2 éxitos en half-open = cierra
+                timeout=60.0             # 60s antes de probar
+            )
+        )
+    
+    def get_provider_name(self) -> str:
+        return f"{self._adapter.get_provider_name()}_protected"
+    
+    def is_available(self) -> bool:
+        return self._adapter.is_available() and not self._circuit_breaker.is_open
+    
+    async def complete(self, prompt: str, config: Optional[LLMConfig] = None) -> LLMResponse:
+        async def _call():
+            return await self._adapter.complete(prompt, config)
+        
+        return await self._circuit_breaker.call(_call)
+    
+    async def complete_structured(
+        self, 
+        prompt: str, 
+        schema: dict,
+        config: Optional[LLMConfig] = None
+    ) -> LLMResponse:
+        async def _call():
+            return await self._adapter.complete_structured(prompt, schema, config)
+        
+        return await self._circuit_breaker.call(_call)
+    
+    @property
+    def circuit_breaker(self) -> CircuitBreaker:
+        return self._circuit_breaker
+    
+    def get_status(self) -> dict:
+        return self._circuit_breaker.get_status()
+    
+    def reset(self):
+        self._circuit_breaker.reset()

--- a/tests/test_circuit_breaker.py
+++ b/tests/test_circuit_breaker.py
@@ -1,0 +1,196 @@
+import pytest
+import asyncio
+from src.infrastructure.resilience.circuit_breaker import (
+    CircuitBreaker,
+    CircuitBreakerConfig,
+    CircuitBreakerOpen,
+    CircuitState
+)
+
+
+class TestCircuitBreaker:
+    """Tests para Circuit Breaker"""
+    
+    def test_initial_state_is_closed(self):
+        cb = CircuitBreaker(name="test")
+        assert cb.state == CircuitState.CLOSED
+        assert cb.is_closed
+    
+    def test_successful_call_does_not_open(self):
+        cb = CircuitBreaker(name="test", config=CircuitBreakerConfig(failure_threshold=3))
+        
+        async def success_func():
+            return "success"
+        
+        for _ in range(5):
+            result = asyncio.run(cb.call(success_func))
+        
+        assert result == "success"
+        assert cb.state == CircuitState.CLOSED
+    
+    def test_failure_count_opens_circuit(self):
+        cb = CircuitBreaker(
+            name="test", 
+            config=CircuitBreakerConfig(failure_threshold=3, timeout=60)
+        )
+        
+        def failing_func():
+            raise ValueError("Test error")
+        
+        success_count = 0
+        for i in range(5):
+            try:
+                cb.call_sync(failing_func)
+            except ValueError:
+                success_count += 1
+            except CircuitBreakerOpen:
+                break
+        
+        assert success_count == 3
+        assert cb.state == CircuitState.OPEN
+    
+    def test_open_circuit_rejects_calls(self):
+        cb = CircuitBreaker(
+            name="test",
+            config=CircuitBreakerConfig(failure_threshold=1, timeout=60)
+        )
+        
+        def fail_once():
+            raise ValueError("Fail")
+        
+        try:
+            cb.call_sync(fail_once)
+        except ValueError:
+            pass
+        
+        with pytest.raises(CircuitBreakerOpen):
+            cb.call_sync(fail_once)
+    
+    def test_half_open_after_timeout(self):
+        cb = CircuitBreaker(
+            name="test",
+            config=CircuitBreakerConfig(failure_threshold=1, timeout=0.1)
+        )
+        
+        def fail():
+            raise ValueError("Fail")
+        
+        try:
+            cb.call_sync(fail)
+        except ValueError:
+            pass
+        
+        assert cb.state == CircuitState.OPEN
+        
+        import time
+        time.sleep(0.2)
+        
+        result = None
+        try:
+            result = cb.call_sync(lambda: "success")
+        except CircuitBreakerOpen:
+            pass
+        
+        assert result == "success"
+        assert cb.state == CircuitState.HALF_OPEN
+    
+    def test_half_open_success_closes_circuit(self):
+        cb = CircuitBreaker(
+            name="test",
+            config=CircuitBreakerConfig(
+                failure_threshold=1, 
+                timeout=0.1,
+                success_threshold=2
+            )
+        )
+        
+        def fail():
+            raise ValueError("Fail")
+        
+        try:
+            cb.call_sync(fail)
+        except ValueError:
+            pass
+        
+        import time
+        time.sleep(0.2)
+        
+        for i in range(3):
+            try:
+                cb.call_sync(lambda: f"success_{i}")
+            except CircuitBreakerOpen:
+                break
+        
+        assert cb.state == CircuitState.CLOSED
+    
+    def test_get_status(self):
+        cb = CircuitBreaker(name="test_status")
+        status = cb.get_status()
+        
+        assert status["name"] == "test_status"
+        assert status["state"] == "closed"
+        assert "stats" in status
+    
+    def test_reset(self):
+        cb = CircuitBreaker(
+            name="test",
+            config=CircuitBreakerConfig(failure_threshold=1)
+        )
+        
+        def fail():
+            raise ValueError("Fail")
+        
+        try:
+            cb.call_sync(fail)
+        except ValueError:
+            pass
+        
+        cb.reset()
+        
+        assert cb.state == CircuitState.CLOSED
+        assert cb.failure_count == 0
+
+
+class TestCircuitBreakerDecorator:
+    """Tests para el decorador de Circuit Breaker"""
+    
+    def test_decorator_creates_circuit_breaker(self):
+        @CircuitBreaker.decorator(failure_threshold=3, name="decorated")
+        async def my_func():
+            return "done"
+        
+        assert hasattr(my_func, 'circuit_breaker')
+        assert my_func.circuit_breaker.name == "decorated"
+
+
+class TestLLMCircuitBreakerAdapter:
+    """Tests para el adapter de LLM con Circuit Breaker"""
+    
+    @pytest.mark.asyncio
+    async def test_successful_call(self):
+        from src.llm.adapters.groq_adapter import GroqAdapter
+        from src.llm.adapters.circuit_breaker_adapter import LLMCircuitBreakerAdapter
+        
+        mock_adapter = GroqAdapter(api_key="test-key")
+        
+        original_complete = mock_adapter.complete
+        
+        async def mock_complete(prompt, config=None):
+            return await original_complete(prompt, config) if mock_adapter.is_available() else None
+        
+        mock_adapter.complete = mock_complete
+        mock_adapter.is_available = lambda: True
+        
+        cb_adapter = LLMCircuitBreakerAdapter(mock_adapter)
+        assert cb_adapter.get_provider_name() == "groq_protected"
+    
+    def test_status(self):
+        from src.llm.adapters.groq_adapter import GroqAdapter
+        from src.llm.adapters.circuit_breaker_adapter import LLMCircuitBreakerAdapter
+        
+        adapter = GroqAdapter(api_key="test")
+        cb_adapter = LLMCircuitBreakerAdapter(adapter)
+        
+        status = cb_adapter.get_status()
+        assert "name" in status
+        assert "state" in status


### PR DESCRIPTION
## Summary

Implementa Circuit Breaker pattern para proteger llamadas a LLM contra cascade failures.

## Problem

Cuando Groq/Gemini/Ollama fallan repetidamente:
- Sistema sigue intentando → más carga
- Errores se acumulan → timeout en cadena
- Un servicio caído afecta todo

## Solution

### Arquitectura

```
┌─────────────────────────────────────────────────────────┐
│                    Circuit Breaker                       │
├─────────────────────────────────────────────────────────┤
│                                                         │
│   CLOSED ──(5 fallos)──→ OPEN ──(60s)──→ HALF_OPEN   │
│     ↑                        │                          │
│     │     (2 éxitos OK)      │                          │
│     └────────────────────────┘                          │
│                                                         │
└─────────────────────────────────────────────────────────┘
```

### Componentes nuevos

| Archivo | Descripción |
|---------|-------------|
| `src/infrastructure/resilience/circuit_breaker.py` | Implementación del patrón |
| `src/llm/adapters/circuit_breaker_adapter.py` | Wrapper para LLMPort |
| `tests/test_circuit_breaker.py` | 11 tests |

### Uso

```python
from src.llm.adapters.circuit_breaker_adapter import LLMCircuitBreakerAdapter
from src.llm.adapters.groq_adapter import GroqAdapter

groq = GroqAdapter()
protected_groq = LLMCircuitBreakerAdapter(groq, name="groq")

# Ahora groq tiene Circuit Breaker
response = await protected_groq.complete(prompt)
```

### Métricas

- **Tests**: 167 passing (11 nuevos)
- **Coverage**: +2% aproximado

## Checklist Resilience
- [x] Circuit Breaker ✅
- [ ] Retry + Backoff
- [ ] Timeout (ya existe en LLMPort)
- [ ] Fallback
- [ ] Rate Limiter

## Related Issue
Closes #42