### PR TITLE
feat: implementar Exponential Backoff para retries (#46)

### DIFF
--- a/src/infrastructure/resilience/retry_policy.py
+++ b/src/infrastructure/resilience/retry_policy.py
@@ -1,0 +1,371 @@
+"""
+Exponential Backoff Retry Pattern
+
+¿Qué es?
+--------
+Imaginate que llamás por teléfono y está ocupado:
+
+1. Esperás 1 segundo, llamás → OCUPADO
+2. Esperás 2 segundos, llamás → OCUPADO  
+3. Esperás 4 segundos, llamás → OCUPADO
+4. Esperás 8 segundos, llamás → OCUPADO
+5. Esperás 16 segundos, llamás → OK!
+
+Espera se duplica cada vez: 1, 2, 4, 8, 16... segundos
+
+Parámetros:
+-----------
+- base_delay: 1 segundo (empieza acá)
+- max_delay: 60 segundos (máximo a esperar)
+- max_retries: 5 (cantidad de intentos)
+- exponential_base: 2 (por cuánto se multiplica)
+
+Cálculo:
+---------
+delay = min(base_delay * (exponential_base ^ attempt), max_delay)
+
+attempt=0: delay = 1 * (2^0) = 1s
+attempt=1: delay = 1 * (2^1) = 2s
+attempt=2: delay = 1 * (2^2) = 4s
+attempt=3: delay = 1 * (2^3) = 8s
+attempt=4: delay = 1 * (2^4) = 16s
+attempt=5: delay = min(32s, 60s) = 32s
+"""
+import asyncio
+import random
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from enum import Enum
+from typing import Optional, Callable, Awaitable, TypeVar, Union
+from functools import wraps
+
+
+T = TypeVar('T')
+
+
+class RetryStrategy(str, Enum):
+    FIXED = "fixed"               # Siempre el mismo delay
+    LINEAR = "linear"             # Incrementa linealmente
+    EXPONENTIAL = "exponential"   # Duplica cada vez (recomendado)
+    FIBONACCI = "fibonacci"      # Secuencia de Fibonacci
+
+
+@dataclass
+class RetryConfig:
+    max_retries: int = 3
+    base_delay: float = 1.0
+    max_delay: float = 60.0
+    exponential_base: float = 2.0
+    strategy: RetryStrategy = RetryStrategy.EXPONENTIAL
+    jitter: bool = True
+    jitter_range: float = 0.3
+    
+
+@dataclass
+class RetryStats:
+    total_attempts: int = 0
+    successful_attempts: int = 0
+    failed_attempts: int = 0
+    total_delay_seconds: float = 0.0
+    last_attempt_at: Optional[datetime] = None
+    errors: list = field(default_factory=list)
+
+
+@dataclass
+class RetryContext:
+    attempt: int
+    max_attempts: int
+    delay: float
+    error: Optional[Exception] = None
+    
+    @property
+    def will_retry(self) -> bool:
+        return self.attempt < self.max_attempts - 1
+    
+    @property
+    def is_last_attempt(self) -> bool:
+        return self.attempt == self.max_attempts - 1
+
+
+class RetryExhausted(Exception):
+    """Excepción cuando se agotaron los retries"""
+    def __init__(self, attempts: int, last_error: Exception):
+        self.attempts = attempts
+        self.last_error = last_error
+        super().__init__(f"Retry exhausted after {attempts} attempts. Last error: {last_error}")
+
+
+class RetryableError(Exception):
+    """Error que puede ser reintentado (transitorio)"""
+    pass
+
+
+def calculate_delay(
+    attempt: int, 
+    config: RetryConfig
+) -> float:
+    """Calcula el delay para un intento específico"""
+    
+    if config.strategy == RetryStrategy.FIXED:
+        delay = config.base_delay
+    
+    elif config.strategy == RetryStrategy.LINEAR:
+        delay = config.base_delay * (attempt + 1)
+    
+    elif config.strategy == RetryStrategy.EXPONENTIAL:
+        delay = config.base_delay * (config.exponential_base ** attempt)
+    
+    elif config.strategy == RetryStrategy.FIBONACCI:
+        a, b = 1, 1
+        for _ in range(attempt):
+            a, b = b, a + b
+        delay = config.base_delay * a
+    
+    else:
+        delay = config.base_delay
+    
+    delay = min(delay, config.max_delay)
+    
+    if config.jitter:
+        jitter_amount = delay * config.jitter_range
+        delay = delay + random.uniform(-jitter_amount, jitter_amount)
+        delay = max(0.1, delay)
+    
+    return delay
+
+
+async def retry_with_backoff(
+    func: Callable[..., Awaitable[T]],
+    config: Optional[RetryConfig] = None,
+    *args,
+    **kwargs
+) -> T:
+    """
+    Ejecuta una función async con retry y exponential backoff.
+    
+    Uso:
+    ----
+    @retry_with_backoff(config=RetryConfig(max_retries=5, base_delay=1.0))
+    async def mi_funcion():
+        return await api.call()
+    
+    # O directo:
+    result = await retry_with_backoff(
+        mi_funcion,
+        RetryConfig(max_retries=3)
+    )
+    """
+    config = config or RetryConfig()
+    last_error = None
+    
+    for attempt in range(config.max_retries):
+        try:
+            if asyncio.iscoroutinefunction(func):
+                result = await func(*args, **kwargs)
+            else:
+                result = await asyncio.to_thread(func, *args, **kwargs)
+            return result
+            
+        except Exception as e:
+            last_error = e
+            
+            if attempt == config.max_retries - 1:
+                raise RetryExhausted(config.max_retries, last_error)
+            
+            delay = calculate_delay(attempt, config)
+            await asyncio.sleep(delay)
+    
+    raise RetryExhausted(config.max_retries, last_error)
+
+
+def retry_decorator(config: Optional[RetryConfig] = None):
+    """
+    Decorador para retry con backoff.
+    
+    Uso:
+    ----
+    @retry_decorator(RetryConfig(max_retries=5))
+    async def mi_funcion():
+        return await api.call()
+    """
+    def decorator(func: Callable[..., Awaitable[T]]) -> Callable[..., Awaitable[T]]:
+        @wraps(func)
+        async def wrapper(*args, **kwargs) -> T:
+            return await retry_with_backoff(func, config, *args, **kwargs)
+        return wrapper
+    return decorator
+
+
+class RetryPolicy:
+    """
+    Política de retry configurable con callbacks.
+    
+    Uso:
+    ----
+    policy = RetryPolicy()
+    policy.on_retry(lambda ctx: logger.warning(f"Retry {ctx.attempt}"))
+    policy.on_success(lambda: metrics.increment("success"))
+    policy.on_failure(lambda ctx: alerts.send(f"Failed after {ctx.max_attempts}"))
+    
+    result = await policy.execute(mi_funcion)
+    """
+    
+    def __init__(self, config: Optional[RetryConfig] = None):
+        self.config = config or RetryConfig()
+        self._on_retry: list[Callable[[RetryContext], None]] = []
+        self._on_success: list[Callable[[], None]] = []
+        self._on_failure: list[Callable[[RetryContext], None]] = []
+        self.stats = RetryStats()
+    
+    def on_retry(self, callback: Callable[[RetryContext], None]):
+        """Callback cuando se hace retry"""
+        self._on_retry.append(callback)
+        return self
+    
+    def on_success(self, callback: Callable[[], None]):
+        """Callback cuando succeede"""
+        self._on_success.append(callback)
+        return self
+    
+    def on_failure(self, callback: Callable[[RetryContext], None]):
+        """Callback cuando falla después de todos los retries"""
+        self._on_failure.append(callback)
+        return self
+    
+    async def execute(self, func: Callable[..., Awaitable[T]], *args, **kwargs) -> T:
+        """Ejecuta una función con la política de retry"""
+        last_error = None
+        
+        for attempt in range(self.config.max_retries):
+            self.stats.total_attempts += 1
+            self.stats.last_attempt_at = datetime.now(timezone.utc)
+            
+            try:
+                if asyncio.iscoroutinefunction(func):
+                    result = await func(*args, **kwargs)
+                else:
+                    result = await asyncio.to_thread(func, *args, **kwargs)
+                
+                self.stats.successful_attempts += 1
+                for callback in self._on_success:
+                    callback()
+                
+                return result
+                
+            except Exception as e:
+                last_error = e
+                self.stats.errors.append(str(e))
+                
+                if attempt == self.config.max_retries - 1:
+                    self.stats.failed_attempts += 1
+                    context = RetryContext(
+                        attempt=attempt,
+                        max_attempts=self.config.max_retries,
+                        delay=0,
+                        error=e
+                    )
+                    for callback in self._on_failure:
+                        callback(context)
+                    raise RetryExhausted(self.config.max_retries, last_error)
+                
+                delay = calculate_delay(attempt, self.config)
+                self.stats.total_delay_seconds += delay
+                
+                context = RetryContext(
+                    attempt=attempt,
+                    max_attempts=self.config.max_retries,
+                    delay=delay,
+                    error=e
+                )
+                
+                for callback in self._on_retry:
+                    callback(context)
+                
+                await asyncio.sleep(delay)
+        
+        raise RetryExhausted(self.config.max_retries, last_error)
+    
+    def get_stats(self) -> dict:
+        """Retorna estadísticas de retry"""
+        return {
+            "config": {
+                "max_retries": self.config.max_retries,
+                "base_delay": self.config.base_delay,
+                "max_delay": self.config.max_delay,
+                "strategy": self.config.strategy.value,
+                "jitter": self.config.jitter
+            },
+            "stats": {
+                "total_attempts": self.stats.total_attempts,
+                "successful_attempts": self.stats.successful_attempts,
+                "failed_attempts": self.stats.failed_attempts,
+                "total_delay_seconds": self.stats.total_delay_seconds,
+                "last_attempt_at": self.stats.last_attempt_at.isoformat() if self.stats.last_attempt_at else None,
+                "error_count": len(self.stats.errors)
+            }
+        }
+
+
+class AsyncRetryHelper:
+    """
+    Helper para hacer retry de múltiples operaciones en paralelo.
+    
+    Uso:
+    ----
+    helper = AsyncRetryHelper()
+    
+    results = await helper.execute_all([
+        (api_call_1, {"arg": 1}),
+        (api_call_2, {"arg": 2}),
+        (api_call_3, {"arg": 3}),
+    ])
+    """
+    
+    def __init__(self, config: Optional[RetryConfig] = None):
+        self.config = config or RetryConfig()
+        self.policy = RetryPolicy(config=self.config)
+    
+    async def execute_all(
+        self, 
+        calls: list[tuple[Callable, dict]]
+    ) -> list:
+        """Ejecuta múltiples llamadas con retry individual"""
+        tasks = []
+        
+        for func, kwargs in calls:
+            task = self.policy.execute(func, **kwargs)
+            tasks.append(task)
+        
+        results = await asyncio.gather(*tasks, return_exceptions=True)
+        return results
+    
+    async def execute_first_success(
+        self,
+        calls: list[tuple[Callable, dict]],
+        timeout: float = 30.0
+    ) -> T:
+        """Ejecuta hasta que una succeede"""
+        tasks = []
+        
+        for func, kwargs in calls:
+            task = asyncio.create_task(self.policy.execute(func, **kwargs))
+            tasks.append(task)
+        
+        done, pending = await asyncio.wait(
+            tasks,
+            timeout=timeout,
+            return_when=asyncio.FIRST_COMPLETED
+        )
+        
+        for task in pending:
+            task.cancel()
+        
+        for task in done:
+            result = task.result()
+            if not isinstance(result, Exception):
+                return result
+        
+        if done:
+            raise done[0].result()
+        
+        raise TimeoutError("All calls timed out")

--- a/tests/test_retry_policy.py
+++ b/tests/test_retry_policy.py
@@ -1,0 +1,284 @@
+import pytest
+import asyncio
+import time
+from unittest.mock import AsyncMock
+
+from src.infrastructure.resilience.retry_policy import (
+    retry_with_backoff,
+    retry_decorator,
+    RetryPolicy,
+    RetryConfig,
+    RetryStrategy,
+    RetryExhausted,
+    RetryContext,
+    calculate_delay,
+    AsyncRetryHelper
+)
+
+
+class TestCalculateDelay:
+    """Tests para calculate_delay"""
+    
+    def test_exponential_delay(self):
+        config = RetryConfig(
+            strategy=RetryStrategy.EXPONENTIAL,
+            base_delay=1.0,
+            max_delay=60.0,
+            jitter=False
+        )
+        
+        assert calculate_delay(0, config) == 1.0
+        assert calculate_delay(1, config) == 2.0
+        assert calculate_delay(2, config) == 4.0
+        assert calculate_delay(3, config) == 8.0
+    
+    def test_linear_delay(self):
+        config = RetryConfig(
+            strategy=RetryStrategy.LINEAR,
+            base_delay=1.0,
+            jitter=False
+        )
+        
+        assert calculate_delay(0, config) == 1.0
+        assert calculate_delay(1, config) == 2.0
+        assert calculate_delay(2, config) == 3.0
+    
+    def test_fixed_delay(self):
+        config = RetryConfig(
+            strategy=RetryStrategy.FIXED,
+            base_delay=2.0,
+            jitter=False
+        )
+        
+        assert calculate_delay(0, config) == 2.0
+        assert calculate_delay(1, config) == 2.0
+        assert calculate_delay(2, config) == 2.0
+    
+    def test_max_delay_respected(self):
+        config = RetryConfig(
+            strategy=RetryStrategy.EXPONENTIAL,
+            base_delay=10.0,
+            max_delay=30.0,
+            jitter=False
+        )
+        
+        assert calculate_delay(10, config) == 30.0
+
+
+class TestRetryWithBackoff:
+    """Tests para retry_with_backoff"""
+    
+    @pytest.mark.asyncio
+    async def test_succeeds_first_attempt(self):
+        async def success_func():
+            return "success"
+        
+        result = await retry_with_backoff(success_func)
+        
+        assert result == "success"
+    
+    @pytest.mark.asyncio
+    async def test_retry_then_success(self):
+        call_count = 0
+        
+        async def flaky_func():
+            nonlocal call_count
+            call_count += 1
+            if call_count < 3:
+                raise ValueError("Temporary error")
+            return "success"
+        
+        result = await retry_with_backoff(
+            flaky_func,
+            RetryConfig(max_retries=5, base_delay=0.01)
+        )
+        
+        assert result == "success"
+        assert call_count == 3
+    
+    @pytest.mark.asyncio
+    async def test_raises_when_exhausted(self):
+        async def always_fail():
+            raise ValueError("Always fails")
+        
+        with pytest.raises(RetryExhausted) as exc_info:
+            await retry_with_backoff(
+                always_fail,
+                RetryConfig(max_retries=3, base_delay=0.01)
+            )
+        
+        assert exc_info.value.attempts == 3
+    
+    @pytest.mark.asyncio
+    async def test_with_args(self):
+        async def func_with_args(a, b, c=0):
+            return a + b + c
+        
+        result = await retry_with_backoff(func_with_args, None, 1, 2, c=3)
+        
+        assert result == 6
+
+
+class TestRetryDecorator:
+    """Tests para retry_decorator"""
+    
+    @pytest.mark.asyncio
+    async def test_decorator_success(self):
+        @retry_decorator(RetryConfig(max_retries=3))
+        async def my_func():
+            return "done"
+        
+        result = await my_func()
+        
+        assert result == "done"
+    
+    @pytest.mark.asyncio
+    async def test_decorator_with_retry(self):
+        call_count = 0
+        
+        @retry_decorator(RetryConfig(max_retries=3, base_delay=0.01))
+        async def flaky():
+            nonlocal call_count
+            call_count += 1
+            if call_count < 2:
+                raise ValueError("Flaky")
+            return "done"
+        
+        result = await flaky()
+        
+        assert result == "done"
+        assert call_count == 2
+
+
+class TestRetryPolicy:
+    """Tests para RetryPolicy"""
+    
+    @pytest.mark.asyncio
+    async def test_basic_retry(self):
+        policy = RetryPolicy(RetryConfig(max_retries=3, base_delay=0.01))
+        
+        call_count = 0
+        
+        async def flaky():
+            nonlocal call_count
+            call_count += 1
+            if call_count < 2:
+                raise ValueError("Flaky")
+            return "success"
+        
+        result = await policy.execute(flaky)
+        
+        assert result == "success"
+        assert call_count == 2
+    
+    @pytest.mark.asyncio
+    async def test_on_retry_callback(self):
+        policy = RetryPolicy(RetryConfig(max_retries=3, base_delay=0.01))
+        
+        retry_contexts = []
+        policy.on_retry(lambda ctx: retry_contexts.append(ctx))
+        
+        call_count = 0
+        
+        async def flaky():
+            nonlocal call_count
+            call_count += 1
+            if call_count < 3:
+                raise ValueError("Flaky")
+            return "success"
+        
+        await policy.execute(flaky)
+        
+        assert len(retry_contexts) == 2
+        assert retry_contexts[0].attempt == 0
+        assert retry_contexts[1].attempt == 1
+    
+    @pytest.mark.asyncio
+    async def test_on_success_callback(self):
+        policy = RetryPolicy(RetryConfig(max_retries=3))
+        
+        success_called = []
+        policy.on_success(lambda: success_called.append(True))
+        
+        async def success():
+            return "done"
+        
+        await policy.execute(success)
+        
+        assert len(success_called) == 1
+    
+    @pytest.mark.asyncio
+    async def test_get_stats(self):
+        policy = RetryPolicy(RetryConfig(max_retries=3))
+        
+        async def success():
+            return "done"
+        
+        await policy.execute(success)
+        
+        stats = policy.get_stats()
+        
+        assert stats["stats"]["successful_attempts"] == 1
+        assert stats["config"]["max_retries"] == 3
+
+
+class TestRetryContext:
+    """Tests para RetryContext"""
+    
+    def test_will_retry(self):
+        ctx = RetryContext(attempt=0, max_attempts=3, delay=1.0)
+        
+        assert ctx.will_retry is True
+        assert ctx.is_last_attempt is False
+    
+    def test_is_last_attempt(self):
+        ctx = RetryContext(attempt=2, max_attempts=3, delay=1.0)
+        
+        assert ctx.will_retry is False
+        assert ctx.is_last_attempt is True
+    
+    def test_will_retry_true_before_last(self):
+        ctx = RetryContext(attempt=3, max_attempts=5, delay=1.0)
+        
+        assert ctx.will_retry is True
+        assert ctx.is_last_attempt is False
+
+
+class TestAsyncRetryHelper:
+    """Tests para AsyncRetryHelper"""
+    
+    @pytest.mark.asyncio
+    async def test_execute_all(self):
+        helper = AsyncRetryHelper(RetryConfig(max_retries=2, base_delay=0.01))
+        
+        async def func1():
+            return "result1"
+        
+        async def func2():
+            return "result2"
+        
+        results = await helper.execute_all([
+            (func1, {}),
+            (func2, {})
+        ])
+        
+        assert results[0] == "result1"
+        assert results[1] == "result2"
+    
+    @pytest.mark.asyncio
+    async def test_execute_first_success(self):
+        helper = AsyncRetryHelper(RetryConfig(max_retries=1, base_delay=0.01))
+        
+        async def slow_fail():
+            await asyncio.sleep(0.5)
+            raise ValueError("Fail")
+        
+        async def fast_success():
+            return "winner"
+        
+        result = await helper.execute_first_success([
+            (fast_success, {}),
+            (slow_fail, {}),
+        ], timeout=5.0)
+        
+        assert result == "winner"


### PR DESCRIPTION
## Summary

Implementa Exponential Backoff para retries con estrategias configurables.

## Problem

Retry inmediato causa sobrecarga en servicios que ya están fallando.

## Solution

```
Attempt 0: esperar 1s
Attempt 1: esperar 2s
Attempt 2: esperar 4s
Attempt 3: esperar 8s
... (duplica cada vez)
```

### Componentes

| Archivo | Descripción |
|---------|-------------|
| `src/infrastructure/resilience/retry_policy.py` | Retry logic completa |
| `tests/test_retry_policy.py` | 19 tests |

### Uso

```python
# Simple
result = await retry_with_backoff(
    mi_funcion,
    RetryConfig(max_retries=5, base_delay=1.0)
)

# Decorador
@retry_decorator(RetryConfig(max_retries=3))
async def mi_funcion():
    return await api.call()

# Con callbacks
policy = RetryPolicy()
policy.on_retry(lambda ctx: logger.warning(f"Retry {ctx.attempt}"))
policy.on_failure(lambda ctx: alerts.send(f"Failed"))
result = await policy.execute(mi_funcion)
```

### Features

- ✅ Exponential Backoff (duplica espera)
- ✅ Estrategias: FIXED, LINEAR, EXPONENTIAL, FIBONACCI
- ✅ Jitter (evita thundering herd)
- ✅ Callbacks para logging/metrics
- ✅ Decorador y función directa
- ✅ 223 tests pasando

## Checklist Resilience
- [x] Circuit Breaker ✅
- [x] Retry + Backoff ✅
- [x] Timeout (ya existe)
- [x] Fallback ✅
- [x] Rate Limiter ✅

## Related Issue
Closes #46