### PR TITLE
feat: add comment publication strategy with ranking and limits (#34)

### DIFF
--- a/src/infrastructure/services/comment_publisher.py
+++ b/src/infrastructure/services/comment_publisher.py
@@ -1,0 +1,164 @@
+from dataclasses import dataclass
+from typing import Optional
+from enum import Enum
+
+
+class Severity(Enum):
+    CRITICAL = "critical"
+    WARNING = "warning"
+    SUGGESTION = "suggestion"
+
+    @property
+    def weight(self) -> float:
+        weights = {
+            Severity.CRITICAL: 1.0,
+            Severity.WARNING: 0.6,
+            Severity.SUGGESTION: 0.3,
+        }
+        return weights[self]
+
+
+@dataclass
+class Finding:
+    file_path: str
+    line_number: int
+    severity: Severity
+    category: str
+    comment: str
+    confidence: float
+    suggested_fix: Optional[str] = None
+    impact: float = 0.5
+
+    @property
+    def score(self) -> float:
+        return (
+            self.severity.weight * 0.5 +
+            self.confidence * 0.3 +
+            self.impact * 0.2
+        )
+
+
+@dataclass
+class FindingGroup:
+    file_path: str
+    finding_type: str
+    count: int
+    representative: Finding
+    summary: str
+
+
+@dataclass
+class PublicationResult:
+    published: list[Finding]
+    grouped: list[FindingGroup]
+    skipped: int
+    total_found: int
+
+
+@dataclass
+class PublicationConfig:
+    max_comments_per_pr: int = 5
+    max_comments_per_file: int = 2
+    min_score_threshold: float = 0.4
+    group_similar: bool = True
+    group_threshold: float = 0.8
+
+
+class CommentRanker:
+    def __init__(self, config: Optional[PublicationConfig] = None):
+        self.config = config or PublicationConfig()
+
+    def rank_findings(self, findings: list[Finding]) -> list[Finding]:
+        scored = [(f.score, f) for f in findings if f.score >= self.config.min_score_threshold]
+        scored.sort(key=lambda x: x[0], reverse=True)
+        return [f for _, f in scored]
+
+    def limit_per_file(self, findings: list[Finding]) -> list[Finding]:
+        by_file: dict[str, list[Finding]] = {}
+        for f in findings:
+            if f.file_path not in by_file:
+                by_file[f.file_path] = []
+            by_file[f.file_path].append(f)
+
+        limited = []
+        for file_path, file_findings in by_file.items():
+            limited.extend(file_findings[:self.config.max_comments_per_file])
+        
+        return limited
+
+    def limit_per_pr(self, findings: list[Finding]) -> list[Finding]:
+        return findings[:self.config.max_comments_per_pr]
+
+    def group_similar(self, findings: list[Finding]) -> tuple[list[Finding], list[FindingGroup]]:
+        if not self.config.group_similar:
+            return findings, []
+
+        by_file_type: dict[tuple[str, str], list[Finding]] = {}
+        for f in findings:
+            key = (f.file_path, f.category)
+            if key not in by_file_type:
+                by_file_type[key] = []
+            by_file_type[key].append(f)
+
+        unique = []
+        groups = []
+
+        for (file_path, category), group_findings in by_file_type.items():
+            if len(group_findings) == 1:
+                unique.append(group_findings[0])
+            else:
+                rep = max(group_findings, key=lambda f: f.score)
+                group = FindingGroup(
+                    file_path=file_path,
+                    finding_type=category,
+                    count=len(group_findings),
+                    representative=rep,
+                    summary=self._generate_group_summary(group_findings)
+                )
+                groups.append(group)
+
+        return unique, groups
+
+    def _generate_group_summary(self, findings: list[Finding]) -> str:
+        if not findings:
+            return ""
+        
+        categories = set(f.category for f in findings)
+        severity = findings[0].severity
+        
+        lines = []
+        if severity == Severity.CRITICAL:
+            lines.append(f"🚨 {len(findings)} issues críticos encontrados:")
+        elif severity == Severity.WARNING:
+            lines.append(f"⚠️ {len(findings)} warnings encontrados:")
+        else:
+            lines.append(f"💡 {len(findings)} sugerencias encontradas:")
+        
+        lines.append(f"Categoría: {', '.join(categories)}")
+        
+        return "\n".join(lines)
+
+    def rank_and_filter(self, findings: list[Finding]) -> PublicationResult:
+        ranked = self.rank_findings(findings)
+        
+        grouped_rank, groups = self.group_similar(ranked)
+        
+        limited_file = self.limit_per_file(grouped_rank)
+        limited_pr = self.limit_per_pr(limited_file)
+        
+        skipped = len(findings) - len(limited_pr) - len(groups)
+        
+        return PublicationResult(
+            published=limited_pr,
+            grouped=groups,
+            skipped=skipped,
+            total_found=len(findings)
+        )
+
+
+def publish_findings(
+    findings: list[Finding],
+    config: Optional[PublicationConfig] = None
+) -> PublicationResult:
+    ranker = CommentRanker(config)
+    return ranker.rank_and_filter(findings)

--- a/tests/test_comment_publisher.py
+++ b/tests/test_comment_publisher.py
@@ -1,0 +1,244 @@
+import pytest
+from src.infrastructure.services.comment_publisher import (
+    CommentRanker,
+    Finding,
+    Severity,
+    PublicationConfig,
+    PublicationResult,
+    publish_findings,
+)
+
+
+class TestFindingScore:
+    def test_critical_has_highest_weight(self):
+        critical = Finding(
+            file_path="test.py",
+            line_number=1,
+            severity=Severity.CRITICAL,
+            category="security",
+            comment="Security issue",
+            confidence=0.9,
+            impact=0.8
+        )
+        
+        assert critical.severity.weight == 1.0
+        assert critical.score > 0.7
+
+    def test_warning_has_medium_weight(self):
+        warning = Finding(
+            file_path="test.py",
+            line_number=1,
+            severity=Severity.WARNING,
+            category="quality",
+            comment="Quality issue",
+            confidence=0.9,
+            impact=0.8
+        )
+        
+        assert warning.severity.weight == 0.6
+
+    def test_suggestion_has_lowest_weight(self):
+        suggestion = Finding(
+            file_path="test.py",
+            line_number=1,
+            severity=Severity.SUGGESTION,
+            category="style",
+            comment="Style suggestion",
+            confidence=0.9,
+            impact=0.8
+        )
+        
+        assert suggestion.severity.weight == 0.3
+
+
+class TestCommentRanker:
+    def test_ranks_by_score(self):
+        config = PublicationConfig(min_score_threshold=0.2)
+        ranker = CommentRanker(config)
+        
+        low_priority = Finding(
+            file_path="test.py",
+            line_number=1,
+            severity=Severity.SUGGESTION,
+            category="style",
+            comment="Minor",
+            confidence=0.6,
+            impact=0.5
+        )
+        
+        high_priority = Finding(
+            file_path="test.py",
+            line_number=1,
+            severity=Severity.CRITICAL,
+            category="security",
+            comment="Critical",
+            confidence=0.9,
+            impact=0.9
+        )
+        
+        ranked = ranker.rank_findings([low_priority, high_priority])
+        
+        assert ranked[0].severity == Severity.CRITICAL
+        assert ranked[1].severity == Severity.SUGGESTION
+
+    def test_filters_below_threshold(self):
+        config = PublicationConfig(min_score_threshold=0.7)
+        ranker = CommentRanker(config)
+        
+        low_score = Finding(
+            file_path="test.py",
+            line_number=1,
+            severity=Severity.SUGGESTION,
+            category="style",
+            comment="Low",
+            confidence=0.3,
+            impact=0.2
+        )
+        
+        high_score = Finding(
+            file_path="test.py",
+            line_number=1,
+            severity=Severity.CRITICAL,
+            category="security",
+            comment="High",
+            confidence=0.9,
+            impact=0.9
+        )
+        
+        ranked = ranker.rank_findings([low_score, high_score])
+        
+        assert len(ranked) == 1
+        assert ranked[0].severity == Severity.CRITICAL
+
+
+class TestLimitPerFile:
+    def test_limits_to_max_per_file(self):
+        config = PublicationConfig(max_comments_per_file=2)
+        ranker = CommentRanker(config)
+        
+        findings = [
+            Finding("a.py", 1, Severity.WARNING, "q", "1", 0.9, 0.5),
+            Finding("a.py", 2, Severity.WARNING, "q", "2", 0.9, 0.5),
+            Finding("a.py", 3, Severity.WARNING, "q", "3", 0.9, 0.5),
+            Finding("b.py", 1, Severity.WARNING, "q", "4", 0.9, 0.5),
+        ]
+        
+        ranked = ranker.rank_findings(findings)
+        limited = ranker.limit_per_file(ranked)
+        
+        a_file_count = sum(1 for f in limited if f.file_path == "a.py")
+        assert a_file_count == 2
+
+
+class TestLimitPerPR:
+    def test_limits_to_max_per_pr(self):
+        config = PublicationConfig(max_comments_per_pr=3)
+        ranker = CommentRanker(config)
+        
+        findings = [
+            Finding("a.py", i, Severity.WARNING, "q", f"{i}", 0.9, 0.5)
+            for i in range(10)
+        ]
+        
+        ranked = ranker.rank_findings(findings)
+        limited = ranker.limit_per_pr(ranked)
+        
+        assert len(limited) == 3
+
+
+class TestGroupSimilar:
+    def test_groups_similar_findings(self):
+        config = PublicationConfig(group_similar=True)
+        ranker = CommentRanker(config)
+        
+        findings = [
+            Finding("a.py", 1, Severity.WARNING, "security", "Issue 1", 0.9, 0.5),
+            Finding("a.py", 5, Severity.WARNING, "security", "Issue 2", 0.9, 0.5),
+            Finding("a.py", 10, Severity.WARNING, "security", "Issue 3", 0.9, 0.5),
+        ]
+        
+        unique, groups = ranker.group_similar(findings)
+        
+        assert len(unique) == 0
+        assert len(groups) == 1
+        assert groups[0].count == 3
+
+    def test_does_not_group_different_categories(self):
+        config = PublicationConfig(group_similar=True)
+        ranker = CommentRanker(config)
+        
+        findings = [
+            Finding("a.py", 1, Severity.WARNING, "security", "Sec 1", 0.9, 0.5),
+            Finding("a.py", 5, Severity.WARNING, "quality", "Qual 1", 0.9, 0.5),
+        ]
+        
+        unique, groups = ranker.group_similar(findings)
+        
+        assert len(unique) == 2
+        assert len(groups) == 0
+
+
+class TestFullPipeline:
+    def test_full_ranking_pipeline(self):
+        config = PublicationConfig(
+            max_comments_per_pr=3,
+            max_comments_per_file=1,
+            min_score_threshold=0.3,
+            group_similar=True
+        )
+        ranker = CommentRanker(config)
+        
+        findings = [
+            Finding("a.py", 1, Severity.SUGGESTION, "style", "S1", 0.5, 0.3),
+            Finding("a.py", 2, Severity.CRITICAL, "security", "C1", 0.9, 0.9),
+            Finding("a.py", 3, Severity.WARNING, "security", "W1", 0.8, 0.6),
+            Finding("b.py", 1, Severity.CRITICAL, "security", "C2", 0.9, 0.9),
+            Finding("b.py", 2, Severity.SUGGESTION, "style", "S2", 0.5, 0.3),
+        ]
+        
+        result = ranker.rank_and_filter(findings)
+        
+        assert isinstance(result, PublicationResult)
+        assert result.total_found == 5
+        assert result.skipped >= 0
+        assert len(result.published) <= 3
+        assert len(result.published) <= len([f for f in findings if f.file_path == "a.py"])
+        
+        for f in result.published:
+            assert f.file_path in ["a.py", "b.py"]
+
+
+class TestPublishFindingsHelper:
+    def test_publish_findings_convenience(self):
+        findings = [
+            Finding("test.py", 1, Severity.CRITICAL, "security", "Critical", 0.9, 0.9),
+            Finding("test.py", 2, Severity.SUGGESTION, "style", "Minor", 0.3, 0.2),
+        ]
+        
+        result = publish_findings(findings)
+        
+        assert result.total_found == 2
+        assert len(result.published) >= 1
+        assert result.published[0].severity == Severity.CRITICAL
+
+
+class TestEdgeCases:
+    def test_empty_findings(self):
+        result = publish_findings([])
+        
+        assert result.total_found == 0
+        assert len(result.published) == 0
+        assert result.skipped == 0
+
+    def test_all_low_score_filtered(self):
+        config = PublicationConfig(min_score_threshold=0.9)
+        
+        findings = [
+            Finding("test.py", 1, Severity.SUGGESTION, "style", "Minor", 0.3, 0.2),
+        ]
+        
+        result = publish_findings(findings, config)
+        
+        assert result.total_found == 1
+        assert len(result.published) == 0
+        assert result.skipped == 1


### PR DESCRIPTION
## Summary

Implementación del issue #34 - estrategia de publicación con límite de comentarios.

### Problema resuelto
- Antes: Se podían generar 20+ comentarios que inundaban al reviewer
- Ahora: Top N comentarios priorizados por relevancia

### Componentes nuevos

**CommentRanker** (`src/infrastructure/services/comment_publisher.py`)
- Scoring de hallazgos: `severity * 0.5 + confidence * 0.3 + impact * 0.2`
- Límite por PR: máximo 5 comentarios (configurable)
- Límite por archivo: máximo 2 comentarios (configurable)
- Agrupación semántica: agrupa hallazgos similares

**PublicationConfig** (configurable)
```python
config = PublicationConfig(
    max_comments_per_pr=5,
    max_comments_per_file=2,
    min_score_threshold=0.4,
    group_similar=True
)
```

### Ejemplo de uso
```python
result = publish_findings(findings)
# result.published = top 5 hallazgos ordenados por score
# result.grouped = grupos semánticos
# result.skipped = cuántos se descartaron
```

### Tests
13 tests pasando cubriendo:
- Scoring de severidades
- Ranking y ordenamiento
- Límites por archivo y PR
- Agrupación semántica
- Pipeline completo

Closes #34