### PR TITLE
fix: add pyproject.toml for editable install

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-${{ hashFiles('requirements.txt') }}
+          key: ${{ runner.os }}-pip-${{ hashFiles('pyproject.toml') }}
           restore-keys: |
             ${{ runner.os }}-pip-
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,40 @@
+[project]
+name = "ai-code-reviewer"
+version = "0.1.0"
+description = "AI Agent that reviews Pull Requests on GitHub"
+readme = "README.md"
+requires-python = ">=3.11"
+dependencies = [
+    "fastapi>=0.115.0",
+    "httpx>=0.27.0",
+    "pydantic>=2.8.0",
+    "python-dotenv>=1.0.0",
+    "uvicorn>=0.30.0",
+    "langgraph>=0.2.56",
+    "pytest>=8.0.0",
+    "pytest-cov>=4.1.0",
+]
+
+[project.optional-dependencies]
+dev = [
+    "ruff",
+    "mypy",
+]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+python_files = ["test_*.py"]
+python_functions = ["test_*"]
+addopts = "-v --cov=src --cov-report=term-missing"
+
+[tool.ruff]
+src = ["src"]
+line-length = 100
+
+[tool.mypy]
+src = ["src"]
+python_version = "3.11"


### PR DESCRIPTION
## Summary
- Add  with project metadata and dependencies
- Update CI cache to use pyproject.toml hash

## Fixes
-  now works in GitHub Actions

Closes #54 (related)