### PR TITLE
fix: add pytest-asyncio for async tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ dependencies = [
     "langgraph>=0.2.56",
     "pytest>=8.0.0",
     "pytest-cov>=4.1.0",
+    "pytest-asyncio>=0.23.0",
 ]
 
 [project.optional-dependencies]
@@ -32,6 +33,7 @@ packages = ["src"]
 testpaths = ["tests"]
 python_files = ["test_*.py"]
 python_functions = ["test_*"]
+asyncio_mode = "auto"
 addopts = "-v --cov=src --cov-report=term-missing"
 
 [tool.ruff]


### PR DESCRIPTION
## Summary
- Add  to dependencies
- Add  to pytest config

## Fixes
- 55 async tests failing due to missing pytest-asyncio

Closes #54 (related)