### PR TITLE
feat: implement prompt caching for token reduction

### DIFF
--- a/src/infrastructure/services/prompt_cache.py
+++ b/src/infrastructure/services/prompt_cache.py
@@ -1,0 +1,158 @@
+import hashlib
+import time
+from dataclasses import dataclass, field
+from typing import Optional
+from datetime import datetime, timezone
+
+
+@dataclass
+class CachedPrompt:
+    content: str
+    hash: str
+    created_at: datetime
+    last_used: datetime
+    tokens_estimate: int
+    hit_count: int = 0
+
+
+@dataclass
+class CacheStats:
+    total_requests: int = 0
+    cache_hits: int = 0
+    cache_misses: int = 0
+    tokens_saved: int = 0
+    last_reset: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
+
+    @property
+    def hit_rate(self) -> float:
+        if self.total_requests == 0:
+            return 0.0
+        return self.cache_hits / self.total_requests
+
+    @property
+    def savings_percent(self) -> float:
+        if self.total_requests == 0:
+            return 0.0
+        return (self.cache_hits / self.total_requests) * 100
+
+
+class PromptCacheConfig:
+    DEFAULT_TTL_SECONDS = 3600
+    DEFAULT_MAX_SIZE = 100
+
+    def __init__(
+        self,
+        ttl_seconds: int = DEFAULT_TTL_SECONDS,
+        max_size: int = DEFAULT_MAX_SIZE,
+        enabled: bool = True
+    ):
+        self.ttl_seconds = ttl_seconds
+        self.max_size = max_size
+        self.enabled = enabled
+
+
+class PromptCache:
+    def __init__(self, config: Optional[PromptCacheConfig] = None):
+        self.config = config or PromptCacheConfig()
+        self._cache: dict[str, CachedPrompt] = {}
+        self._stats = CacheStats()
+        self._lock = None
+
+    def _get_hash(self, content: str) -> str:
+        return hashlib.sha256(content.encode()).hexdigest()[:16]
+
+    def _estimate_tokens(self, content: str) -> int:
+        return len(content) // 4
+
+    def get(self, prompt: str) -> Optional[CachedPrompt]:
+        if not self.config.enabled:
+            return None
+
+        self._stats.total_requests += 1
+        prompt_hash = self._get_hash(prompt)
+
+        cached = self._cache.get(prompt_hash)
+        if cached is None:
+            self._stats.cache_misses += 1
+            return None
+
+        age = (datetime.now(timezone.utc) - cached.created_at).total_seconds()
+        if age > self.config.ttl_seconds:
+            del self._cache[prompt_hash]
+            self._stats.cache_misses += 1
+            return None
+
+        cached.last_used = datetime.now(timezone.utc)
+        cached.hit_count += 1
+        self._stats.cache_hits += 1
+        self._stats.tokens_saved += cached.tokens_estimate
+
+        return cached
+
+    def set(self, prompt: str) -> CachedPrompt:
+        if not self.config.enabled:
+            return CachedPrompt(
+                content=prompt,
+                hash=self._get_hash(prompt),
+                created_at=datetime.now(timezone.utc),
+                last_used=datetime.now(timezone.utc),
+                tokens_estimate=self._estimate_tokens(prompt)
+            )
+
+        prompt_hash = self._get_hash(prompt)
+
+        if prompt_hash in self._cache:
+            cached = self._cache[prompt_hash]
+            cached.last_used = datetime.now(timezone.utc)
+            return cached
+
+        if len(self._cache) >= self.config.max_size:
+            self._evict_oldest()
+
+        cached = CachedPrompt(
+            content=prompt,
+            hash=prompt_hash,
+            created_at=datetime.now(timezone.utc),
+            last_used=datetime.now(timezone.utc),
+            tokens_estimate=self._estimate_tokens(prompt)
+        )
+
+        self._cache[prompt_hash] = cached
+        return cached
+
+    def _evict_oldest(self):
+        if not self._cache:
+            return
+
+        oldest_key = min(
+            self._cache.keys(),
+            key=lambda k: self._cache[k].last_used
+        )
+        del self._cache[oldest_key]
+
+    def invalidate(self, prompt_hash: str = None):
+        if prompt_hash:
+            self._cache.pop(prompt_hash, None)
+        else:
+            self._cache.clear()
+
+    def get_stats(self) -> CacheStats:
+        return self._stats
+
+    def reset_stats(self):
+        self._stats = CacheStats()
+
+    def cleanup_expired(self) -> int:
+        now = datetime.now(timezone.utc)
+        expired_keys = [
+            k for k, v in self._cache.items()
+            if (now - v.created_at).total_seconds() > self.config.ttl_seconds
+        ]
+
+        for key in expired_keys:
+            del self._cache[key]
+
+        return len(expired_keys)
+
+
+prompt_cache = PromptCache()

--- a/tests/test_prompt_cache.py
+++ b/tests/test_prompt_cache.py
@@ -1,0 +1,152 @@
+import pytest
+from datetime import datetime, timezone, timedelta
+from src.infrastructure.services.prompt_cache import (
+    PromptCache,
+    PromptCacheConfig,
+    CachedPrompt,
+    CacheStats,
+)
+
+
+class TestPromptCacheConfig:
+    def test_default_config(self):
+        config = PromptCacheConfig()
+        assert config.ttl_seconds == 3600
+        assert config.max_size == 100
+        assert config.enabled is True
+
+    def test_custom_config(self):
+        config = PromptCacheConfig(ttl_seconds=7200, max_size=50, enabled=False)
+        assert config.ttl_seconds == 7200
+        assert config.max_size == 50
+        assert config.enabled is False
+
+
+class TestCacheStats:
+    def test_initial_stats(self):
+        stats = CacheStats()
+        assert stats.total_requests == 0
+        assert stats.cache_hits == 0
+        assert stats.cache_misses == 0
+        assert stats.tokens_saved == 0
+        assert stats.hit_rate == 0.0
+
+    def test_hit_rate_calculation(self):
+        stats = CacheStats(total_requests=10, cache_hits=3, cache_misses=7)
+        assert stats.hit_rate == 0.3
+
+    def test_savings_percent(self):
+        stats = CacheStats(total_requests=100, cache_hits=75, cache_misses=25)
+        assert stats.savings_percent == 75.0
+
+
+class TestCachedPrompt:
+    def test_cached_prompt_creation(self):
+        now = datetime.now(timezone.utc)
+        prompt = CachedPrompt(
+            content="test prompt",
+            hash="abc123",
+            created_at=now,
+            last_used=now,
+            tokens_estimate=100
+        )
+        assert prompt.content == "test prompt"
+        assert prompt.hash == "abc123"
+        assert prompt.hit_count == 0
+
+
+class TestPromptCache:
+    def test_cache_miss_on_empty(self):
+        cache = PromptCache()
+        result = cache.get("test prompt")
+        assert result is None
+
+    def test_cache_set_and_get(self):
+        cache = PromptCache()
+        cache.set("test prompt")
+        result = cache.get("test prompt")
+        assert result is not None
+        assert result.content == "test prompt"
+
+    def test_cache_hit_increments_counter(self):
+        cache = PromptCache()
+        cache.set("test prompt")
+        cache.get("test prompt")
+        cache.get("test prompt")
+        stats = cache.get_stats()
+        assert stats.cache_hits == 2
+
+    def test_different_prompts_different_cache(self):
+        cache = PromptCache()
+        cache.set("prompt 1")
+        cache.set("prompt 2")
+        assert cache.get("prompt 1") is not None
+        assert cache.get("prompt 2") is not None
+        assert cache.get("prompt 1").content == "prompt 1"
+
+    def test_cache_disabled(self):
+        config = PromptCacheConfig(enabled=False)
+        cache = PromptCache(config)
+        cache.set("test prompt")
+        result = cache.get("test prompt")
+        assert result is None
+
+    def test_max_size_eviction(self):
+        config = PromptCacheConfig(max_size=2)
+        cache = PromptCache(config)
+        cache.set("prompt 1")
+        cache.set("prompt 2")
+        cache.set("prompt 3")
+        assert cache.get("prompt 1") is None
+        assert cache.get("prompt 2") is not None
+        assert cache.get("prompt 3") is not None
+
+    def test_invalidate_specific(self):
+        cache = PromptCache()
+        cache.set("prompt 1")
+        cached = cache.get("prompt 1")
+        cache.invalidate(cached.hash)
+        assert cache.get("prompt 1") is None
+
+    def test_invalidate_all(self):
+        cache = PromptCache()
+        cache.set("prompt 1")
+        cache.set("prompt 2")
+        cache.invalidate()
+        assert cache.get("prompt 1") is None
+        assert cache.get("prompt 2") is None
+
+    def test_tokens_estimate(self):
+        cache = PromptCache()
+        cached = cache.set("test prompt")
+        assert cached.tokens_estimate > 0
+
+    def test_hit_count_tracking(self):
+        cache = PromptCache()
+        cache.set("test prompt")
+        cache.get("test prompt")
+        cached = cache.get("test prompt")
+        assert cached.hit_count == 2
+
+    def test_cleanup_expired(self):
+        config = PromptCacheConfig(ttl_seconds=1)
+        cache = PromptCache(config)
+        cache.set("test prompt")
+        import time
+        time.sleep(1.1)
+        removed = cache.cleanup_expired()
+        assert removed >= 1
+        assert cache.get("test prompt") is None
+
+    def test_reset_stats(self):
+        cache = PromptCache()
+        cache.set("prompt 1")
+        cache.get("prompt 1")
+        cache.reset_stats()
+        stats = cache.get_stats()
+        assert stats.total_requests == 0
+        assert stats.cache_hits == 0
+
+    def test_global_instance(self):
+        from src.infrastructure.services.prompt_cache import prompt_cache
+        assert isinstance(prompt_cache, PromptCache)


### PR DESCRIPTION
## Summary
- Add PromptCache class with TTL (default 1h) and max_size configuration
- Add CacheStats for tracking hits, misses and tokens saved
- Add PromptCacheConfig for configurable settings (enabled, ttl, max_size)
- Add 19 comprehensive tests

## Changes
- `src/infrastructure/services/prompt_cache.py` - New cache service
- `tests/test_prompt_cache.py` - 19 tests

## Usage
```python
from src.infrastructure.services.prompt_cache import prompt_cache, PromptCacheConfig

# Get cached prompt
cached = prompt_cache.get(system_prompt)
if cached:
    # Use cached version
    pass

# Cache new prompt
prompt_cache.set(system_prompt)

# Get stats
stats = prompt_cache.get_stats()
print(f"Hit rate: {stats.hit_rate}")
```

Closes #69